### PR TITLE
Adds support for options.headers to be a Headers instance with an entries method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "unfetch",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,13 +1,13 @@
-export default function (url, options) {
+export default function(url, options) {
 	options = options || {};
-	return new Promise((resolve, reject) => {
+	return new Promise( (resolve, reject) => {
 		const request = new XMLHttpRequest();
 		const keys = [];
 		const all = [];
 		const headers = {};
 
 		const response = () => ({
-			ok: (request.status / 100 | 0) == 2,		// 200-299
+			ok: (request.status/100|0) == 2,		// 200-299
 			statusText: request.statusText,
 			status: request.status,
 			url: request.responseURL,
@@ -36,9 +36,9 @@ export default function (url, options) {
 
 		request.onerror = reject;
 
-		request.withCredentials = options.credentials == 'include';
+		request.withCredentials = options.credentials=='include';
 
-		if (options.headers && typeof options.headers.entries === 'function') {
+		if (options.headers && typeof options.headers.entries==='function') {
 			// Iterate through options.headers as a Headers instance
 			for (const pair of options.headers.entries()) {
 				request.setRequestHeader(pair[0], pair[1]);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,13 +1,13 @@
-export default function(url, options) {
+export default function (url, options) {
 	options = options || {};
-	return new Promise( (resolve, reject) => {
+	return new Promise((resolve, reject) => {
 		const request = new XMLHttpRequest();
 		const keys = [];
 		const all = [];
 		const headers = {};
 
 		const response = () => ({
-			ok: (request.status/100|0) == 2,		// 200-299
+			ok: (request.status / 100 | 0) == 2,		// 200-299
 			statusText: request.statusText,
 			status: request.status,
 			url: request.responseURL,
@@ -36,10 +36,19 @@ export default function(url, options) {
 
 		request.onerror = reject;
 
-		request.withCredentials = options.credentials=='include';
+		request.withCredentials = options.credentials == 'include';
 
-		for (const i in options.headers) {
-			request.setRequestHeader(i, options.headers[i]);
+		if (options.headers && typeof options.headers.entries === 'function') {
+			// Iterate through options.headers as a Headers instance
+			for (const pair of options.headers.entries()) {
+				request.setRequestHeader(pair[0], pair[1]);
+			}
+		}
+		else {
+			// Iterate through options.headers as a POJO
+			for (const i in options.headers) {
+				request.setRequestHeader(i, options.headers[i]);
+			}
 		}
 
 		request.send(options.body || null);

--- a/test/index.js
+++ b/test/index.js
@@ -80,5 +80,28 @@ describe('unfetch', () => {
 
 			return p;
 		});
+
+		it('supports options.headers as a Headers instance', () => {
+			let requestHeaders = {
+				pairs: [
+					['a', 'b'],
+					['content-type', 'application/json']
+				],
+				entries() {
+					return this.pairs;
+				}
+			};
+			let p = fetch('/foo', { headers: requestHeaders })
+				.then(r => r.json())
+				.then(data => {
+					expect(xhr.setRequestHeader).toHaveBeenCalledTimes(2);
+					expect(xhr.setRequestHeader).toHaveBeenNthCalledWith(1, 'a', 'b');
+					expect(xhr.setRequestHeader).toHaveBeenNthCalledWith(2, 'content-type', 'application/json');
+				});
+
+			xhr.onload();
+
+			return p;
+		});
 	});
 });


### PR DESCRIPTION
This PR is fixing the issue outlined in (#124). This allows consumers to use a Headers instance in their raw `fetch(url, options)` call for `options.headers`, instead of being limited to only JavaScript object literals.

The polyfill will now check if `options.headers` has an `entries()` function. If it does, it will invoke that and expect to receive an iterable object, like the [Headers.entries() API does](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries), and then iterate over that.

With this change, request headers as a Headers instance will be properly iterated and carried over correctly to the underlying XHR, instead of the current implementation which iterates on the method keys (`append()`, `delete()`, etc)

Unfortunately I could not add this support while keeping the original package under 500b, so I plan to limit these changes to my personal fork of unfetch.

I created a PR on the original repo here: https://github.com/developit/unfetch/pull/125
But I closed this PR since there is a strong focus on keeping bundle size low (~500b or less), and at best I was only able to add this support at ~550b.